### PR TITLE
Added missing license and copyright lines

### DIFF
--- a/.reuse/templates/template.jinja2
+++ b/.reuse/templates/template.jinja2
@@ -1,0 +1,11 @@
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for contributor_line in contributor_lines %}
+SPDX-FileContributor: {{ contributor_line }}
+{% endfor %}
+All rights reserved.
+See LICENSE file in this distribution.
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing to Tie Die
 
 ## Reporting issues.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Welcome to TieDie IoT
 
 This package enables IoT device provisioning and communication for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Security Policies and Procedures
 
 This document outlines security procedures and general policies for the

--- a/gateway/.gitignore
+++ b/gateway/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 # For more information, please refer to https://aka.ms/vscode-docker-python
 FROM python:3.10-slim
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # TieDie Gateway functionality
 
 This directory contains code necessary to run a SCIM and NIPC gateway

--- a/gateway/db/init.sql
+++ b/gateway/db/init.sql
@@ -1,2 +1,7 @@
+-- Copyright (c) 2023, Cisco and/or its affiliates.
+-- All rights reserved.
+-- See LICENSE file in this distribution.
+-- SPDX-License-Identifier: Apache-2.0
+
 CREATE DATABASE tiedie;
 

--- a/gateway/docker-compose.debug.yml
+++ b/gateway/docker-compose.debug.yml
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 version: '3.4'
 
 services:

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 version: '3.4'
 
 services:

--- a/gateway/proto/data_app.proto
+++ b/gateway/proto/data_app.proto
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 option java_package = "com.cisco.tiedie.proto";

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # TieDie SDK for Java
 
 This SDK is used to access IOT devices via the virtualized interfaces

--- a/java-sdk/sample-java-app/Dockerfile
+++ b/java-sdk/sample-java-app/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 FROM eclipse-temurin:17-jdk-alpine
 
 WORKDIR /

--- a/java-sdk/sample-java-app/README.md
+++ b/java-sdk/sample-java-app/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Getting Started
 
 This is an example of how the TieDie Java SDK can be used to develop an application. 

--- a/java-sdk/sample-java-app/build.gradle
+++ b/java-sdk/sample-java-app/build.gradle
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.0.6'

--- a/java-sdk/sample-java-app/docker-compose.yaml
+++ b/java-sdk/sample-java-app/docker-compose.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   tiedie-sample-app:
     image: tiedie-java-sample-app:latest

--- a/java-sdk/sample-java-app/settings.gradle
+++ b/java-sdk/sample-java-app/settings.gradle
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 rootProject.name = 'tiedie-sample-app'
 
 includeBuild '../sdk'

--- a/java-sdk/sample-java-app/src/main/resources/META-INF/additional-spring-configuration-metadata.json.license
+++ b/java-sdk/sample-java-app/src/main/resources/META-INF/additional-spring-configuration-metadata.json.license
@@ -1,0 +1,4 @@
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0

--- a/java-sdk/sample-java-app/src/main/resources/templates/advertisement.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/advertisement.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/device.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/device.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/device_add.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/device_add.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/devices.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/devices.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/error.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/error.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/index.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/index.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/layout.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/layout.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <head th:fragment="head">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/java-sdk/sample-java-app/src/main/resources/templates/subscription.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/subscription.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sample-java-app/src/main/resources/templates/subscriptions.html
+++ b/java-sdk/sample-java-app/src/main/resources/templates/subscriptions.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 

--- a/java-sdk/sdk/build.gradle
+++ b/java-sdk/sdk/build.gradle
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 plugins {
     id 'java-library'
     id "io.freefair.lombok" version "8.0.0-rc4"

--- a/java-sdk/sdk/settings.gradle
+++ b/java-sdk/sdk/settings.gradle
@@ -1,2 +1,7 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 rootProject.name = 'tiedie-sdk-java'
 

--- a/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleCharacteristic.java
+++ b/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleCharacteristic.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2023, Cisco and/or its affiliates.
 // All rights reserved.
-// See license in distribution for details.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.cisco.tiedie.dto.control.ble;
 

--- a/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleDescriptors.java
+++ b/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleDescriptors.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2023, Cisco and/or its affiliates.
 // All rights reserved.
-// See license in distribution for details.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.cisco.tiedie.dto.control.ble;
 

--- a/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleDiscoverRequest.java
+++ b/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleDiscoverRequest.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2023, Cisco and/or its affiliates.
 // All rights reserved.
-// See license in distribution for details.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.cisco.tiedie.dto.control.ble;
 

--- a/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleService.java
+++ b/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/ble/BleService.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2023, Cisco and/or its affiliates.
 // All rights reserved.
-// See license in distribution for details.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.cisco.tiedie.dto.control.ble;
 

--- a/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/internal/TiedieDiscoverRequest.java
+++ b/java-sdk/sdk/src/main/java/com/cisco/tiedie/dto/control/internal/TiedieDiscoverRequest.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2023, Cisco and/or its affiliates.
 // All rights reserved.
-// See license in distribution for details.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
 
 package com.cisco.tiedie.dto.control.internal;
 

--- a/java-sdk/sdk/src/main/proto/data_app.proto
+++ b/java-sdk/sdk/src/main/proto/data_app.proto
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 option java_package = "com.cisco.tiedie.proto";

--- a/java-sdk/sdk/src/test/java/com/cisco/tiedie/clients/utils/CertificateHelper.java
+++ b/java-sdk/sdk/src/test/java/com/cisco/tiedie/clients/utils/CertificateHelper.java
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.cisco.tiedie.clients.utils;
 
 import java.io.ByteArrayInputStream;

--- a/python-sdk/Dockerfile
+++ b/python-sdk/Dockerfile
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 # For more information, please refer to https://aka.ms/vscode-docker-python
 FROM python:3.10-slim
 

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # TieDie SDK for Python
 
 See accompanying LICENSE file in this distribution.

--- a/python-sdk/docker-compose.yaml
+++ b/python-sdk/docker-compose.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2023, Cisco and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   tiedie-sample-app:
     image: tiedie-sample-app:latest

--- a/python-sdk/sample-python-app/README.md
+++ b/python-sdk/sample-python-app/README.md
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Tiedie Python Sample App
 
 Copyright (c) 2023, Cisco Systems, Inc. and/or its affiliates.

--- a/python-sdk/sample-python-app/src/templates/advertisement.html
+++ b/python-sdk/sample-python-app/src/templates/advertisement.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 {% block main %}

--- a/python-sdk/sample-python-app/src/templates/device.html
+++ b/python-sdk/sample-python-app/src/templates/device.html
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
 {% extends 'layout.html' %}
 
 {% block main %}

--- a/python-sdk/sample-python-app/src/templates/device_add.html
+++ b/python-sdk/sample-python-app/src/templates/device_add.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 {% block main %}

--- a/python-sdk/sample-python-app/src/templates/devices.html
+++ b/python-sdk/sample-python-app/src/templates/devices.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 <title>{% block title %}Devices{% endblock %}</title>

--- a/python-sdk/sample-python-app/src/templates/error.html
+++ b/python-sdk/sample-python-app/src/templates/error.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 {% block main %}

--- a/python-sdk/sample-python-app/src/templates/index.html
+++ b/python-sdk/sample-python-app/src/templates/index.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 {% block main %}

--- a/python-sdk/sample-python-app/src/templates/layout.html
+++ b/python-sdk/sample-python-app/src/templates/layout.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/python-sdk/sample-python-app/src/templates/subscription.html
+++ b/python-sdk/sample-python-app/src/templates/subscription.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 
 <title>{% block title %}Subscription{% endblock %}</title>

--- a/python-sdk/sample-python-app/src/templates/subscriptions.html
+++ b/python-sdk/sample-python-app/src/templates/subscriptions.html
@@ -1,3 +1,10 @@
+<!--
+Copyright (c) 2023, Cisco and/or its affiliates.
+All rights reserved.
+See LICENSE file in this distribution.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 {% extends 'layout.html' %}
 <title>{% block title %}Subscriptions{% endblock %}</title>
 {% block main %}

--- a/python-sdk/tiedie_pylib/api/proto/data_app.proto
+++ b/python-sdk/tiedie_pylib/api/proto/data_app.proto
@@ -1,3 +1,8 @@
+// Copyright (c) 2023, Cisco and/or its affiliates.
+// All rights reserved.
+// See LICENSE file in this distribution.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 option java_package = "com.cisco.tiedie.proto";


### PR DESCRIPTION
Here's the output of `reuse lint`: 
```
# MISSING COPYRIGHT AND LICENSING INFORMATION

The following files have no copyright and licensing information:
* .gitignore
* gateway/.dockerignore
* gateway/.gitignore
* gateway/certs/tiedie-ca-openssl.cnf
* gateway/config.ini
* gateway/proto/data_app_pb2.py
* gateway/proto/data_app_pb2.pyi
* gateway/requirements.txt
* gateway/silabs/api/sl_bt.xapi
* gateway/silabs/api/sl_btmesh.xapi
* gateway/silabs/common/libcpc_wrapper.py
* java-sdk/.idea/gradle.xml
* java-sdk/.idea/inspectionProfiles/Project_Default.xml
* java-sdk/.idea/markdown.xml
* java-sdk/.idea/misc.xml
* java-sdk/.idea/uiDesigner.xml
* java-sdk/.idea/vcs.xml
* java-sdk/.idea/workspace.xml
* java-sdk/.vscode/launch.json
* java-sdk/.vscode/settings.json
* java-sdk/sample-java-app/.gitignore
* java-sdk/sample-java-app/config/application.properties
* java-sdk/sample-java-app/gradle/wrapper/gradle-wrapper.jar
* java-sdk/sample-java-app/gradle/wrapper/gradle-wrapper.properties
* java-sdk/sample-java-app/src/main/resources/application.properties
* java-sdk/sdk/.gitignore
* java-sdk/sdk/gradle/wrapper/gradle-wrapper.jar
* java-sdk/sdk/gradle/wrapper/gradle-wrapper.properties
* java-sdk/sdk/lombok.config
* python-sdk/.gitignore
* python-sdk/sample-python-app/config/config.ini
* python-sdk/sample-python-app/requirements.txt
* python-sdk/tiedie_pylib/api/proto/data_app_pb2.py
* python-sdk/tiedie_pylib/api/proto/data_app_pb2.pyi

The following files have no licensing information:
* java-sdk/sample-java-app/gradlew
* java-sdk/sample-java-app/gradlew.bat
* java-sdk/sdk/gradlew
* java-sdk/sdk/gradlew.bat


# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: Apache-2.0, Zlib
* Unused licenses: 0
* Used licenses: Apache-2.0, Zlib
* Read errors: 0
* files with copyright information: 162 / 196
* files with license information: 158 / 196

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
```