### PR TITLE
56 normalize database to support multiple technologies

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -48,7 +48,7 @@ def onboarding_apiauth(name):
 
 def mqtt_connect() -> mqtt.Client:
     """ Function MQTT connect """
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
     client.tls_set(ca_certs="ca_certificates/ca.pem")
     client.tls_insecure_set(True)
     client.username_pw_set("admin", "admin")

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -10,7 +10,6 @@ and serves a secure Flask web application with MQTT and BLE integration.
 
 """
 
-import datetime
 import uuid
 import ssl
 
@@ -48,7 +47,7 @@ def onboarding_apiauth(name):
 
 def mqtt_connect() -> mqtt.Client:
     """ Function MQTT connect """
-    client = mqtt.Client()
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     client.tls_set(ca_certs="ca_certificates/ca.pem")
     client.tls_insecure_set(True)
     client.username_pw_set("admin", "admin")

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -10,6 +10,7 @@ and serves a secure Flask web application with MQTT and BLE integration.
 
 """
 
+import datetime
 import uuid
 import ssl
 

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -30,7 +30,7 @@ from models import (
     EndpointApp,
     GattTopic,
     CoreDevice,
-    BleDevice
+    BleDevice,
     AdvFilter
 )
 

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -29,7 +29,7 @@ from models import (
     DataAppTopic,
     EndpointApp,
     GattTopic,
-    BleDevice,
+    BleExtension,
     AdvFilter
 )
 
@@ -92,7 +92,7 @@ def get_connection():
 def get_connection_by_id(device_id: str):
     """ Get connection state for a device """
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     conn = ble_ap().get_connection(device.device_mac_address)
 
@@ -107,7 +107,7 @@ def get_connection_by_id(device_id: str):
 def connect_by_id(device_id: str):
     """ Connect API """
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().connect(device.device_mac_address,
                             BleConnectOptions(
@@ -131,7 +131,7 @@ def connect():
     cache_idle_purge = ble.get("cacheIdlePurge", 3600)
 
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     resp, respcode = ble_ap().connect(device.device_mac_address,
                                       BleConnectOptions(
@@ -146,7 +146,7 @@ def connect():
 def disconnect_by_id(device_id: str):
     """ Disconnect API """
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().disconnect(device.device_mac_address)
 
@@ -158,7 +158,7 @@ def disconnect():
     device_id = request.args.get("id")
 
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().disconnect(device.device_mac_address)
 
@@ -168,7 +168,7 @@ def disconnect():
 def discover_by_id(device_id: str):
     """ Service discovery API """
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().discover(device.device_mac_address,
                              BleConnectOptions(
@@ -185,7 +185,7 @@ def discover():
     device_id = request.args.get("id")
 
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     services = request.args.getlist("ble[services][serviceID]")
     cached = request.args.get("ble[cached]", False)
@@ -211,7 +211,7 @@ def read():
     characteristic_id = request.args["ble[characteristicID]"].lower()
 
     device = session.execute(
-        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
     resp, respcode = ble_ap().read(
         device.device_mac_address, service_id, characteristic_id)
@@ -233,7 +233,7 @@ def write():
     characteristic_id = ble["characteristicID"].lower()
     value = request.json["value"].lower()
 
-    device = session.scalar(select(BleDevice).filter_by(id=device_id))
+    device = session.scalar(select(BleExtension).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -257,7 +257,7 @@ def subscribe():
     service_id = ble["serviceID"].lower()
     characteristic_id = ble["characteristicID"].lower()
 
-    device = session.scalar(select(BleDevice).filter_by(id=device_id))
+    device = session.scalar(select(BleExtension).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -275,7 +275,7 @@ def subscribe():
         characteristic_id = ble["characteristicID"].lower()
 
         device = session.execute(
-            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
         gatt_topic = GattTopic(
             topic, service_id, characteristic_id, data_format, [device])
@@ -298,7 +298,7 @@ def unsubscribe():
     service_id = ble["serviceID"].lower()
     characteristic_id = ble["characteristicID"].lower()
 
-    device = session.scalar(select(BleDevice).filter_by(id=device_id))
+    device = session.scalar(select(BleExtension).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -331,7 +331,7 @@ def register_topic():
         characteristic_id = ble["characteristicID"].lower()
 
         device = session.execute(
-            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
         gatt_topic = GattTopic(
             topic, service_id, characteristic_id, data_format, [device])
@@ -339,7 +339,7 @@ def register_topic():
         session.commit()
     elif ad_type == "connection_events":
         device = session.execute(
-            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
         if not device:
             return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -351,7 +351,7 @@ def register_topic():
     elif ad_type == "advertisements":
         if device_id is not None:
             device = session.execute(
-                select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
+                select(BleExtension).filter_by(id=device_id)).scalar_one_or_none()
 
             if device is None:
                 return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -590,7 +590,7 @@ def get_topics_by_data_app(data_app_id: str):
 @authenticate_user
 def get_topics_by_device_id(device_id: str):
     """ Fetch registered topics information """
-    device = session.scalar(select(BleDevice).filter_by(id=device_id))
+    device = session.scalar(select(BleExtension).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -618,7 +618,7 @@ def get_topics_by_device_id(device_id: str):
 @authenticate_user
 def delete_topics_by_device_id(device_id: str):
     """ Function to unregister topic """
-    device = session.scalar(select(BleDevice).filter_by(id=device_id))
+    device = session.scalar(select(BleExtension).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -29,7 +29,8 @@ from models import (
     DataAppTopic,
     EndpointApp,
     GattTopic,
-    Device,
+    CoreDevice,
+    BleDevice
     AdvFilter
 )
 
@@ -92,7 +93,7 @@ def get_connection():
 def get_connection_by_id(device_id: str):
     """ Get connection state for a device """
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     conn = ble_ap().get_connection(device.device_mac_address)
 
@@ -107,7 +108,7 @@ def get_connection_by_id(device_id: str):
 def connect_by_id(device_id: str):
     """ Connect API """
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().connect(device.device_mac_address,
                             BleConnectOptions(
@@ -131,7 +132,7 @@ def connect():
     cache_idle_purge = ble.get("cacheIdlePurge", 3600)
 
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     resp, respcode = ble_ap().connect(device.device_mac_address,
                                       BleConnectOptions(
@@ -146,7 +147,7 @@ def connect():
 def disconnect_by_id(device_id: str):
     """ Disconnect API """
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().disconnect(device.device_mac_address)
 
@@ -158,7 +159,7 @@ def disconnect():
     device_id = request.args.get("id")
 
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().disconnect(device.device_mac_address)
 
@@ -168,7 +169,7 @@ def disconnect():
 def discover_by_id(device_id: str):
     """ Service discovery API """
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     return ble_ap().discover(device.device_mac_address,
                              BleConnectOptions(
@@ -185,7 +186,7 @@ def discover():
     device_id = request.args.get("id")
 
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     services = request.args.getlist("ble[services][serviceID]")
     cached = request.args.get("ble[cached]", False)
@@ -211,7 +212,7 @@ def read():
     characteristic_id = request.args["ble[characteristicID]"].lower()
 
     device = session.execute(
-        select(Device).filter_by(id=device_id)).scalar_one_or_none()
+        select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
     resp, respcode = ble_ap().read(
         device.device_mac_address, service_id, characteristic_id)
@@ -233,7 +234,7 @@ def write():
     characteristic_id = ble["characteristicID"].lower()
     value = request.json["value"].lower()
 
-    device = session.scalar(select(Device).filter_by(id=device_id))
+    device = session.scalar(select(BleDevice).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -257,7 +258,7 @@ def subscribe():
     service_id = ble["serviceID"].lower()
     characteristic_id = ble["characteristicID"].lower()
 
-    device = session.scalar(select(Device).filter_by(id=device_id))
+    device = session.scalar(select(BleDevice).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -298,7 +299,7 @@ def unsubscribe():
     service_id = ble["serviceID"].lower()
     characteristic_id = ble["characteristicID"].lower()
 
-    device = session.scalar(select(Device).filter_by(id=device_id))
+    device = session.scalar(select(BleDevice).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -331,7 +332,7 @@ def register_topic():
         characteristic_id = ble["characteristicID"].lower()
 
         device = session.execute(
-            select(Device).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
         gatt_topic = GattTopic(
             topic, service_id, characteristic_id, data_format, [device])
@@ -339,7 +340,7 @@ def register_topic():
         session.commit()
     elif ad_type == "connection_events":
         device = session.execute(
-            select(Device).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
         if not device:
             return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -351,7 +352,7 @@ def register_topic():
     elif ad_type == "advertisements":
         if device_id is not None:
             device = session.execute(
-                select(Device).filter_by(id=device_id)).scalar_one_or_none()
+                select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
             if device is None:
                 return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST
@@ -618,7 +619,7 @@ def get_topics_by_device_id(device_id: str):
 @authenticate_user
 def delete_topics_by_device_id(device_id: str):
     """ Function to unregister topic """
-    device = session.scalar(select(Device).filter_by(id=device_id))
+    device = session.scalar(select(BleDevice).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -29,7 +29,6 @@ from models import (
     DataAppTopic,
     EndpointApp,
     GattTopic,
-    CoreDevice,
     BleDevice,
     AdvFilter
 )
@@ -276,7 +275,7 @@ def subscribe():
         characteristic_id = ble["characteristicID"].lower()
 
         device = session.execute(
-            select(Device).filter_by(id=device_id)).scalar_one_or_none()
+            select(BleDevice).filter_by(id=device_id)).scalar_one_or_none()
 
         gatt_topic = GattTopic(
             topic, service_id, characteristic_id, data_format, [device])
@@ -591,7 +590,7 @@ def get_topics_by_data_app(data_app_id: str):
 @authenticate_user
 def get_topics_by_device_id(device_id: str):
     """ Fetch registered topics information """
-    device = session.scalar(select(Device).filter_by(id=device_id))
+    device = session.scalar(select(BleDevice).filter_by(id=device_id))
 
     if device is None:
         return jsonify({"status": "FAILURE"}), HTTPStatus.BAD_REQUEST

--- a/gateway/data_producer.py
+++ b/gateway/data_producer.py
@@ -15,7 +15,7 @@ from flask import Flask
 import paho.mqtt.client as mqtt
 from sqlalchemy import Column, func, and_, select
 from database import session
-from models import AdvTopic, GattTopic, BleDevice
+from models import AdvTopic, GattTopic, BleExtension
 from proto import data_app_pb2
 
 
@@ -115,9 +115,9 @@ class DataProducer:
                              value: bytes):
         """ Publish GATT notifications/indications to registered MQTT topics """
         with self.app.app_context():
-            user = session.scalar(select(BleDevice)
-                                  .join(GattTopic, BleDevice.gatt_topics)
-                                  .where(and_(BleDevice.device_mac_address == mac_address,
+            user = session.scalar(select(BleExtension)
+                                  .join(GattTopic, BleExtension.gatt_topics)
+                                  .where(and_(BleExtension.device_mac_address == mac_address,
                                               GattTopic.service_uuid == service_uuid,
                                               GattTopic.characteristic_uuid == char_uuid)))
 
@@ -142,8 +142,8 @@ class DataProducer:
     def publish_advertisement(self, evt):
         """ Publishes filtered BLE advertisements to MQTT topics based on conditions. """
         with self.app.app_context():
-            user = session.scalar(select(BleDevice).filter(
-                func.lower(BleDevice.device_mac_address) == func.lower(evt.address)))
+            user = session.scalar(select(BleExtension).filter(
+                func.lower(BleExtension.device_mac_address) == func.lower(evt.address)))
 
             adv_topics = list(session.scalars(
                 select(AdvTopic).filter_by(onboarded=False)).all())
@@ -170,8 +170,8 @@ class DataProducer:
     def publish_connection_status(self, evt, address, connected: bool):
         """ Publishes BLE connection status updates to MQTT topics based on conditions. """
         with self.app.app_context():
-            user = session.scalar(select(BleDevice).filter(
-                func.lower(BleDevice.device_mac_address) == func.lower(address)))
+            user = session.scalar(select(BleExtension).filter(
+                func.lower(BleExtension.device_mac_address) == func.lower(address)))
 
             if user is None:
                 return

--- a/gateway/data_producer.py
+++ b/gateway/data_producer.py
@@ -115,7 +115,7 @@ class DataProducer:
                              value: bytes):
         """ Publish GATT notifications/indications to registered MQTT topics """
         with self.app.app_context():
-            user = session.scalar(select(Device)
+            user = session.scalar(select(BleDevice)
                                   .join(GattTopic, Device.gatt_topics)
                                   .where(and_(Device.device_mac_address == mac_address,
                                               GattTopic.service_uuid == service_uuid,

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -65,7 +65,7 @@ devices_endpoint_apps = db.Table(
 class Device(db.Model):
     """ Core elements of Tiedie devices."""
     __tablename__ = "devices"
-    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    device_id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     schemas = mapped_column(String)
     device_display_name = mapped_column(String)
     admin_state = mapped_column(Boolean)
@@ -82,7 +82,7 @@ class Device(db.Model):
             admin_state,
             created_time
     ):
-        self.id = device_id
+        self.device_id = device_id
         self.schemas = schemas
         self.device_display_name = device_display_name
         self.admin_state = admin_state
@@ -93,7 +93,7 @@ class Device(db.Model):
         """serialize function"""
         response = {
             "schemas" : self.schemas,
-            "id": self.id,
+            "id": self.device_id,
             "deviceDisplayName": self.device_display_name,
             "adminState": self.admin_state,
             "meta": {"resourceType": "Device",
@@ -108,7 +108,8 @@ class BleExtension(db.Model):
     """ Represent BLE device information and associated data fields. """
     __tablename__ = "bledevices"
 
-    device_id = mapped_column(ForeignKey("devices.id"),primary_key=True)
+    device_id = mapped_column(UUID(as_uuid=True),ForeignKey("devices.device_id"),
+                              primary_key=True)
     device_mac_address = mapped_column(String)
     version_support = mapped_column(ARRAY(String))
     is_random = mapped_column(Boolean())
@@ -151,7 +152,7 @@ class BleExtension(db.Model):
         pairing_oobrn,
         endpoint_apps,
     ):
-        self.id = device_id
+        self.device_id = device_id
         self.device_mac_address = device_mac_address
         self.version_support = version_support
         self.is_random = is_random
@@ -167,7 +168,7 @@ class BleExtension(db.Model):
             self.endpoint_apps.extend(endpoint_apps)
 
     def __repr__(self):
-        return f"<id {self.id}>"
+        return f"<id {self.device_id}>"
 
     def serialize(self):
         """serialize function"""

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -200,7 +200,7 @@ class BleDevice(db.Model):
                     "key": self.pairing_oob_key,
                     "randNumber": self.pairing_oobrn
             }
-
+        core["schemas"].append("urn:ietf:params:scim:schemas:extension:ble:2.0:Device")
         if self.endpoint_apps is not None:
             core["schemas"].append(
                 "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device")

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -78,14 +78,13 @@ class Device(db.Model):
 
     def __init__(
             self,
-            device_id,
             schemas,
             device_display_name,
             admin_state,
             endpoint_apps,
             created_time
     ):
-        self.device_id = device_id
+
         self.schemas = schemas
         self.device_display_name = device_display_name
         self.admin_state = admin_state

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -28,7 +28,7 @@ gatt_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("gatt_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
     ),
 )
 
@@ -38,7 +38,7 @@ adv_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("adv_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
     ),
 )
 
@@ -48,7 +48,7 @@ connection_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("connection_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
     ),
 )
 
@@ -57,7 +57,7 @@ devices_endpoint_apps = db.Table(
     Column("endpoint_app_id", UUID(as_uuid=True),
            ForeignKey("endpoint_app.id"), primary_key=True),
     Column(
-        "device_id", UUID(as_uuid=True), ForeignKey("bledevices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), ForeignKey("devices.id"), primary_key=True
     ),
 )
 

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -163,7 +163,7 @@ class BleDevice(db.Model):
     def __repr__(self):
         return f"<id {self.id}>"
 
-    def serialize(self):
+    def serialize(self,core):
         """serialize function"""
         response = {
             "urn:ietf:params:scim:schemas:extension:ble:2.0:Device": {
@@ -171,10 +171,7 @@ class BleDevice(db.Model):
                 "deviceMacAddress": self.device_mac_address,
                 "isRandom": self.is_random,
                 "pairingMethods": self.pairing_methods,
-            },
-            "meta": {"resourceType": "Device",
-                     "created": self.created_time,
-                     "lastModified": self.modified_time},
+            }
         }
 
         if self.irk:
@@ -205,9 +202,9 @@ class BleDevice(db.Model):
             }
 
         if self.endpoint_apps is not None:
-            response["schemas"].append(
+            core["schemas"].append(
                 "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device")
-            response["urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device"] = \
+            core["urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device"] = \
                 {
                 "applications": [{"value": app.id,
                                   "$ref":  f"https://{EXTERNAL_HOST}:"

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -190,13 +190,11 @@ class BleExtension(db.Model):
         response = {
             "urn:ietf:params:scim:schemas:extension:ble:2.0:Device": {
                 "versionSupport": self.version_support,
+                "deviceMacAddress": self.device_mac_address,
                 "isRandom": self.is_random,
                 "pairingMethods": self.pairing_methods,
             }
         }
-
-        if self.device_mac_address:
-            response['deviceMacAddress'] = self.device_mac_address
         if self.irk:
             response["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
                 "irk"] = self.irk

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -28,7 +28,7 @@ gatt_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("gatt_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.device_id"), primary_key=True
     ),
 )
 
@@ -38,7 +38,7 @@ adv_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("adv_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.device_id"), primary_key=True
     ),
 )
 
@@ -48,7 +48,7 @@ connection_topic_devices = db.Table(
         "topic", String(), db.ForeignKey("connection_topics.topic"), primary_key=True
     ),
     Column(
-        "device_id", UUID(as_uuid=True), db.ForeignKey("devices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), db.ForeignKey("bledevices.device_id"), primary_key=True
     ),
 )
 
@@ -57,7 +57,7 @@ devices_endpoint_apps = db.Table(
     Column("endpoint_app_id", UUID(as_uuid=True),
            ForeignKey("endpoint_app.id"), primary_key=True),
     Column(
-        "device_id", UUID(as_uuid=True), ForeignKey("devices.id"), primary_key=True
+        "device_id", UUID(as_uuid=True), ForeignKey("bledevices.device_id"), primary_key=True
     ),
 )
 

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -90,7 +90,7 @@ class CoreDevice(db.Model):
     def serialize(self):
         """serialize function"""
         response = {
-            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Device"]
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Device"],
             "id": self.id,
             "deviceDisplayName": self.device_display_name,
             "adminState": self.admin_state,

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -143,10 +143,10 @@ class BleExtension(db.Model):
     pairing_oob_key = mapped_column(String)
     pairing_oobrn = mapped_column(BigInteger)
 
-    gatt_topics = relationship("GattTopic",
+    gatt_topics: Mapped[List["GattTopic"]] = relationship("GattTopic",
                                secondary=gatt_topic_devices, back_populates="devices")
 
-    adv_topics = relationship("AdvTopic",
+    adv_topics: Mapped[List["AdvTopic"]] = relationship("AdvTopic",
                               secondary=adv_topic_devices, back_populates="devices")
 
     connection_topics: Mapped[List["ConnectionTopic"]] = \

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -196,7 +196,7 @@ class BleExtension(db.Model):
         }
 
         if self.device_mac_address:
-            response['device_mac_address'] = self.device_mac_address
+            response['deviceMacAddress'] = self.device_mac_address
         if self.irk:
             response["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
                 "irk"] = self.irk

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -77,8 +77,7 @@ class CoreDevice(db.Model):
             schemas,
             device_display_name,
             admin_state,
-            endpoint_apps,
-            created_time,
+            created_time
     ):
         self.id = device_id
         self.schemas = schemas
@@ -86,7 +85,7 @@ class CoreDevice(db.Model):
         self.admin_state = admin_state
         self.created_time = created_time
         self.modified_time = created_time
-    
+
     def serialize(self):
         """serialize function"""
         response = {
@@ -98,6 +97,7 @@ class CoreDevice(db.Model):
                      "created": self.created_time,
                      "lastModified": self.modified_time},
             }
+        return response
 
 class BleDevice(db.Model):
     """ Represent BLE device information and associated data fields. """
@@ -282,7 +282,7 @@ class GattTopic(db.Model):
     characteristic_uuid = Column(String())
     data_format = Column(Enum("default", "payload", name="data_format"))
 
-    devices: Mapped[List[Device]] = relationship(
+    devices: Mapped[List[BleDevice]] = relationship(
         secondary=gatt_topic_devices, back_populates="gatt_topics")
 
     def __init__(self, topic, service_uuid, characteristic_uuid, data_format, devices):
@@ -322,7 +322,7 @@ class AdvTopic(db.Model):
 
     topic = Column(String(), primary_key=True, unique=True)
     data_format = Column(Enum("default", "payload", name="data_format"))
-    devices: Mapped[List[Device]] = relationship(
+    devices: Mapped[List[BleDevice]] = relationship(
         secondary=adv_topic_devices, back_populates="adv_topics")
     onboarded = Column(Boolean, default=False)
     filter_type = Column(String())
@@ -350,7 +350,7 @@ class ConnectionTopic(db.Model):
 
     topic = Column(String(), primary_key=True, unique=True)
     data_format = Column(Enum("default", "payload", name="data_format"))
-    devices: Mapped[List[Device]] = relationship(
+    devices: Mapped[List[BleDevice]] = relationship(
         secondary=connection_topic_devices, back_populates="connection_topics")
 
     def __init__(self, topic: str, data_format, devices: Any):

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -84,7 +84,7 @@ def scim_addusers():
 
 @scim_app.route("/Devices/<string:device_id>", methods=["GET"])
 @authenticate_user
-def get_user(device_id):
+def get_entry(device_id):
     """
     SCIM API: Retrieve user data by ID and onboardApp parameters.
     If not found, a "User not found" response with a status code of 404

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -69,8 +69,8 @@ def add_scim_entry():
             created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         )
         # Dispatch to appropriate function
-#        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
-#            ble_create_device(request)
+        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device:NOTHERE' in schemas:
+            ble_create_device(request)
         session.add(entry)
         session.commit()
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -81,16 +81,15 @@ def add_scim_entry():
     # Add device core object
     try:
         entry = Device(
-            device_id=device_id,
             schemas=schemas,
             device_display_name=request.json["deviceDisplayName"],
             admin_state=request.json["adminState"],
             endpoint_apps=endpoint_apps,
             created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         )
-        # Dispatch to appropriate function
         if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
-            ble_create_device(request,device_id)
+            entry.ble_extension = ble_create_device(request,device_id)
+        # Dispatch to appropriate function
         session.add(entry)
         session.commit()
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -68,9 +68,9 @@ def add_scim_entry():
     appextschema = \
         'urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device'
     endpoint_apps_ext = request.json.get(appextschema, None)
-    if not appextschema in schemas:
-        schemas.append(appextschema)
     if endpoint_apps_ext:
+        if not appextschema in schemas:
+            schemas.append(appextschema)
         applications = endpoint_apps_ext.get("applications")
         endpoint_app_ids = [app.get("value") for app in applications]
         # Select all endpoint apps from the database

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -188,13 +188,13 @@ def update_user(entry_id):
     core.update(ble_extension)
     return make_response(jsonify(core),200)
 
-@scim_app.route("/Devices/<string:user_id>", methods=["DELETE"])
+@scim_app.route("/Devices/<string:entry_id>", methods=["DELETE"])
 @authenticate_user
 def delete_device(entry_id):
     """Delete SCIM User"""
     entry = CoreDevice.query.get(entry_id)
     if not entry:
-        return blow_an_error("Device not found",500)
+        return blow_an_error("Device not found",404)
     session.delete(entry)
     ble_entry = BleDevice.query.get(entry_id)
     if ble_entry:

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -131,7 +131,7 @@ def get_devices():
 
     serialized_entries=[]
     for entry in entries:
-        serialized_entry=entry.serialized()
+        serialized_entry=entry.serialize()
         ble_entry=session.get(BleDevice,entry.device_id)
         if ble_entry:
             serialized_entry.update(ble_entry.serialize())

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -98,7 +98,7 @@ def get_entry(device_id):
     entry = session.get(BleDevice,device_id)
     if entry:
         core.update(entry.serialize())
-    return jsonify(entry)
+    return jsonify(core)
 
 
 @scim_app.route("/Devices", methods=["GET"])

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -295,7 +295,7 @@ def create_endpoint():
 @authenticate_user
 def delete_endpoint(device_id):
     """ Deletes SCIM endpoint app by ID, handles not-found case, returns responses. """
-    endpoint_app = session.get(EndPointApp,device_id)
+    endpoint_app = session.get(EndpointApp,device_id)
     if not endpoint_app:
         return blow_an_error("Endpoint App not found",404)
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -69,8 +69,8 @@ def add_scim_entry():
             created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         )
         # Dispatch to appropriate function
-        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
-            ble_create_device(request)
+#        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
+#            ble_create_device(request)
         session.add(entry)
         session.commit()
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -16,7 +16,7 @@ from functools import wraps
 from flask import Blueprint, jsonify, make_response, request, current_app
 from sqlalchemy import select
 from werkzeug.test import EnvironBuilder
-from tiedie_exceptions import DeviceExists,IDNotAllowedOnCreate
+from tiedie_exceptions import DeviceExists
 from database import session
 from models import EndpointApp, BleExtension, Device, OnboardingAppKey
 from util import make_hash
@@ -60,14 +60,14 @@ def add_scim_entry():
     device_id=request.json.get("id")
 
     if device_id:
-        return(blow_an_error("Specifying id on create not permitted", 400))
-        
+        return blow_an_error("Specifying id on create not permitted", 400)
+
     device_id = uuid.uuid4()
 
     # Add device core object
     try:
         entry = Device(
-#            device_id=device_id,
+            device_id=device_id,
             schemas=request.json["schemas"],
             device_display_name=request.json["deviceDisplayName"],
             admin_state=request.json["adminState"],

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -17,7 +17,7 @@ from flask import Blueprint, jsonify, make_response, request, current_app
 from sqlalchemy import select
 from werkzeug.test import EnvironBuilder
 from database import session
-from models import EndpointApp, CoreDevice, OnboardingAppKey
+from models import EndpointApp, BleDevice, CoreDevice, OnboardingAppKey
 from util import make_hash
 from scim_ble import ble_create_device,ble_update_device
 from scim_error import blow_an_error
@@ -78,7 +78,7 @@ def scim_addusers():
         core.update(ble_extensions)
     else:
         return blow_an_error("Extension not implemented.",501)
-        
+
     return make_response(jsonify(core),200)
 
 
@@ -135,7 +135,7 @@ def get_devices():
         ble_entry=BleDevice.query.get(entry.device_id)
         if ble_entry:
             serialized_entry.update(ble_entry.serialize())
-        serialized_entries.append(serialized.entry)
+        serialized_entries.append(serialized_entry)
 
 
     return make_response(
@@ -192,9 +192,9 @@ def update_user(entry_id):
 @authenticate_user
 def delete_device(entry_id):
     """Delete SCIM User"""
-    entry = Device.query.get(entry_id)
-    if not user:
-        return blow_an_error("User not found",404)
+    entry = CoreDevice.query.get(entry_id)
+    if not entry:
+        return blow_an_error("Device not found",404)
     session.delete(entry)
     ble_entry = BleDevice.query.get(entry_id)
     if ble_entry:

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -79,7 +79,7 @@ def scim_addusers():
     else:
         return blow_an_error("Extension not implemented.",501)
 
-    return make_response(jsonify(core),200)
+    return make_response(jsonify(core),201)
 
 
 @scim_app.route("/Devices/<string:device_id>", methods=["GET"])

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -194,7 +194,7 @@ def delete_device(entry_id):
     """Delete SCIM User"""
     entry = CoreDevice.query.get(entry_id)
     if not entry:
-        return blow_an_error("Device not found",404)
+        return blow_an_error("Device not found",500)
     session.delete(entry)
     ble_entry = BleDevice.query.get(entry_id)
     if ble_entry:

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -47,7 +47,7 @@ def authenticate_user(func):
 
 @scim_app.route('/Devices', methods=['POST'])
 @authenticate_user
-def add_scim_entry():
+def create_device():
     """
     This code defines a SCIM API endpoint for creating users,
     extracts data from the request JSON, and stores user information in a database.
@@ -96,7 +96,7 @@ def add_scim_entry():
         core=entry.serialize()
 
     except DeviceExists:
-        return blow_an_error("Device already exists", 500)
+        return blow_an_error("Device already exists", 409,"uniqueness")
     except Exception as e:
         return blow_an_error(str(e),400)
 
@@ -105,7 +105,7 @@ def add_scim_entry():
 
 @scim_app.route("/Devices/<string:device_id>", methods=["GET"])
 @authenticate_user
-def get_entry(device_id):
+def read_device(device_id):
     """
     SCIM API: Retrieve user data by ID and onboardApp parameters.
     If not found, a "User not found" response with a status code of 404
@@ -120,7 +120,7 @@ def get_entry(device_id):
 
 @scim_app.route("/Devices", methods=["GET"])
 @authenticate_user
-def get_devices():
+def read_devices():
     """Get SCIM Devices"""
     start_index = 1
     count = None
@@ -140,7 +140,7 @@ def get_devices():
         entries = []
         if ble_entries:
             for ble_entry in ble_entries:
-                entries.update(ble_entry.device)
+                entries.append(ble_entry.device)
     else:
         entries = Device.query.paginate(
             page=start_index, per_page=count, error_out=False).items
@@ -167,7 +167,7 @@ def get_devices():
 
 @scim_app.route("/Devices/<string:entry_id>", methods=["PUT"])
 @authenticate_user
-def update_entry(entry_id):
+def update_device(entry_id):
     """
     Function to retrieve SCIM device data based on parameters like start
     index, count, and filters.
@@ -213,7 +213,7 @@ def delete_device(entry_id):
 
 @scim_app.route("/EndpointApps/<string:id>", methods=["GET"])
 @authenticate_user
-def get_endpoint(endpoint_id):
+def read_endpoint(endpoint_id):
     """Get SCIM Endpoint"""
     endpoint_app = session.scalar(
         select(EndpointApp).filter_by(id=endpoint_id))
@@ -225,7 +225,7 @@ def get_endpoint(endpoint_id):
 
 @scim_app.route("/EndpointApps", methods=["GET"])
 @authenticate_user
-def get_endpoints():
+def read_endpoints():
     """Get SCIM Endpoint"""
     start_index = 1
     count = None

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -135,7 +135,7 @@ def read_devices():
         single_filter = request.args["filter"].split(" ")
         filter_value = single_filter[2].strip('"')
 
-        ble_entries = BleExtension.query.filter_by(device_mac_address=filter_value).first()
+        ble_entries = BleExtension.query.filter_by(device_mac_address=filter_value).all()
 
         entries = []
         if ble_entries:

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -80,12 +80,16 @@ def scim_addusers():
             )
         session.add(entry)
         session.commit()
+        core_entry=entry.serialize()
     except Exception as e:
         return blow_an_error(str(e),400)
 
     # Dispatch to appropriate function
     if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
-        return ble_create_device(request)
+        ble_extension= ble_create_device(request)
+        core_entry.update(ble_extensions)
+    return make_response(jsonify(core_entry),200)
+    
     return blow_an_error("Extension not implemented.",501)
 
 @scim_app.route("/Devices/<string:user_id>", methods=["GET"])

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -180,7 +180,7 @@ def update_entry(entry_id):
 
         ble_json=request.json[
             "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"]
-        ble_entry=ble_update_device(ble_json)
+        ble_entry=ble_update_device(ble_json,core)
     else:
         return blow_an_error("Extension not implemented.",501)
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -63,7 +63,7 @@ def scim_addusers():
             device_id=request.json.get("id"),
             schemas=request.json["schemas"],
             device_display_name=request.json["deviceDisplayName"],
-            admin_state=request.json["adminState"], 
+            admin_state=request.json["adminState"],
             )
         session.add(entry)
         session.commit()
@@ -76,7 +76,7 @@ def scim_addusers():
         ble_extension= ble_create_device(request)
         core.update(ble_extensions)
     return make_response(jsonify(core),200)
-    
+
     return blow_an_error("Extension not implemented.",501)
 
 @scim_app.route("/Devices/<string:user_id>", methods=["GET"])

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -190,10 +190,10 @@ def delete_device(entry_id):
 
 @scim_app.route("/EndpointApps/<string:id>", methods=["GET"])
 @authenticate_user
-def get_endpoint(device_id):
+def get_endpoint(endpoint_id):
     """Get SCIM Endpoint"""
     endpoint_app = session.scalar(
-        select(EndpointApp).filter_by(id=device_id))
+        select(EndpointApp).filter_by(id=endpoint_id))
     if not endpoint_app:
         return blow_an_error("Endpoint App not found",404)
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -69,7 +69,7 @@ def add_scim_entry():
             created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
         )
         # Dispatch to appropriate function
-        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device:NOTHERE' in schemas:
+        if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
             ble_create_device(request)
         session.add(entry)
         session.commit()

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -132,7 +132,7 @@ def get_devices():
     serialized_entries=[]
     for entry in entries:
         serialized_entry=entry.serialize()
-        ble_entry=session.get(BleDevice,entry.device_id)
+        ble_entry=session.get(BleDevice,entry.id)
         if ble_entry:
             serialized_entry.update(ble_entry.serialize())
         serialized_entries.append(serialized_entry)

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -74,7 +74,7 @@ def scim_addusers():
 
     # Dispatch to appropriate function
     if 'urn:ietf:params:scim:schemas:extension:ble:2.0:Device' in schemas:
-        ble_extensions= ble_create_device(request)
+        ble_extensions= ble_create_device(request,core)
         core.update(ble_extensions)
     else:
         return blow_an_error("Extension not implemented.",501)
@@ -154,7 +154,7 @@ def get_devices():
 
 @scim_app.route("/Devices/<string:entry_id>", methods=["PUT"])
 @authenticate_user
-def update_user(entry_id):
+def update_entry(entry_id):
     """
     Function to retrieve SCIM device data based on parameters like start
     index, count, and filters.
@@ -184,7 +184,7 @@ def update_user(entry_id):
     else:
         return blow_an_error("Extension not implemented.",501)
 
-    ble_extension=ble_entry.serialize()
+    ble_extension=ble_entry.serialize(core)
     core.update(ble_extension)
     return make_response(jsonify(core),200)
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -90,12 +90,12 @@ def get_user(device_id):
     If not found, a "User not found" response with a status code of 404
     is returned.
     """
-    entry = CoreDevice.query.get(device_id)
+    entry = session.get(CoreDevice,device_id)
     if not entry:
         return blow_an_error("Device not found",404)
 
     core=entry.serialize()
-    entry = BleDevice.query.get(device_id)
+    entry = session.get(BleDevice,device_id)
     if entry:
         core.update(entry.serialize())
     return jsonify(entry)
@@ -132,7 +132,7 @@ def get_devices():
     serialized_entries=[]
     for entry in entries:
         serialized_entry=entry.serialized()
-        ble_entry=BleDevice.query.get(entry.device_id)
+        ble_entry=session.get(BleDevice,entry.device_id)
         if ble_entry:
             serialized_entry.update(ble_entry.serialize())
         serialized_entries.append(serialized_entry)
@@ -164,7 +164,7 @@ def update_entry(entry_id):
     if not request.json:
         return blow_an_error("Request body is not valid JSON.",400)
 
-    entry: CoreDevice = CoreDevice.query.get(entry_id)
+    entry: CoreDevice = session.get(CoreDevice,entry_id)
 
     if not entry:
         return blow_an_error("Device not found",404)
@@ -192,11 +192,11 @@ def update_entry(entry_id):
 @authenticate_user
 def delete_device(entry_id):
     """Delete SCIM User"""
-    entry = CoreDevice.query.get(entry_id)
+    entry = session.get(CoreDevice,entry_id)
     if not entry:
         return blow_an_error("Device not found",404)
     session.delete(entry)
-    ble_entry = BleDevice.query.get(entry_id)
+    ble_entry = session.get(BleDevice,entry_id)
     if ble_entry:
         session.delete(ble_entry)
     session.commit()
@@ -295,7 +295,7 @@ def create_endpoint():
 @authenticate_user
 def delete_endpoint(device_id):
     """ Deletes SCIM endpoint app by ID, handles not-found case, returns responses. """
-    endpoint_app = EndpointApp.query.get(device_id)
+    endpoint_app = session.get(EndPointApp,device_id)
     if not endpoint_app:
         return blow_an_error("Endpoint App not found",404)
 

--- a/gateway/scim.py
+++ b/gateway/scim.py
@@ -16,12 +16,12 @@ from functools import wraps
 from flask import Blueprint, jsonify, make_response, request, current_app
 from sqlalchemy import select
 from werkzeug.test import EnvironBuilder
+from tiedie_exceptions import DeviceExists
 from database import session
 from models import EndpointApp, BleExtension, Device, OnboardingAppKey
 from util import make_hash
 from scim_ble import ble_create_device,ble_update_device
 from scim_error import blow_an_error
-from tiedie_exceptions import DeviceExists
 
 scim_app = Blueprint("scim", __name__, url_prefix="/scim/v2")
 

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -10,7 +10,7 @@ This module implements BLE dispatch for SCIM.
 import datetime
 from flask import jsonify, make_response
 from sqlalchemy import select
-from models import EndpointApp, Device
+from models import EndpointApp, BleDevice
 from database import session
 
 
@@ -67,11 +67,8 @@ def ble_create_device(request):
         )
 
     try:
-        user = Device(
+        entry = BleDevice(
             device_id=device_id,
-            schemas=request.json["schemas"],
-            device_display_name=request.json["deviceDisplayName"],
-            admin_state=request.json["adminState"],
             version_support = request.json[
                 "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
                     "versionSupport"),
@@ -98,7 +95,7 @@ def ble_create_device(request):
             endpoint_apps=endpoint_apps,
             created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
         )
-        session.add(user)
+        session.add(entry)
 
         session.commit()
         return make_response(jsonify(user.serialize()), 201)

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -53,8 +53,9 @@ def ble_create_device(request):
         device_mac_address=device_mac_address).first()
 
     if existing_device:
-        raise DeviceExists
-
+        raise DeviceExists("Device Exists")
+    if device_id:
+        return
     entry = BleExtension(
         device_id=device_id,
         version_support = ble_json.get("versionSupport"),

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -7,9 +7,8 @@
 This module implements BLE dispatch for SCIM.
 """
 
-from sqlalchemy import select
 from tiedie_exceptions import DeviceExists
-from models import EndpointApp, BleExtension
+from models import BleExtension
 from database import session
 
 def ble_create_device(request,device_id):
@@ -25,16 +24,6 @@ def ble_create_device(request,device_id):
     pairing_pass_key = None
     pairing_oob_key = None
     pairing_oobrn = None
-
-    endpoint_apps = None
-    endpoint_apps_ext = request.json.get(
-        "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device", None)
-    if endpoint_apps_ext:
-        applications = endpoint_apps_ext.get("applications")
-        endpoint_app_ids = [app.get("value") for app in applications]
-        # Select all endpoint apps from the database
-        endpoint_apps = session.scalars(select(EndpointApp).filter(
-            EndpointApp.id.in_(endpoint_app_ids))).all()
 
     if pairing_just_works:
         pairing_just_works_key = pairing_just_works.get("key")
@@ -68,7 +57,6 @@ def ble_create_device(request,device_id):
         pairing_pass_key=pairing_pass_key,
         pairing_oob_key=pairing_oob_key,
         pairing_oobrn=pairing_oobrn,
-        endpoint_apps=endpoint_apps
     )
     session.add(entry)
 

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -35,7 +35,7 @@ def ble_create_device(request,device_id):
         # Select all endpoint apps from the database
         endpoint_apps = session.scalars(select(EndpointApp).filter(
             EndpointApp.id.in_(endpoint_app_ids))).all()
-    
+
     if pairing_just_works:
         pairing_just_works_key = pairing_just_works.get("key")
     pairing_pass = ble_json.get(

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -51,7 +51,7 @@ def ble_create_device(request):
         pairing_oobrn = pairing.get("randNumber")
     device_id = request.json.get("id")
 
-    existing_device = Device.query.filter_by(
+    existing_device = BleDevice.query.filter_by(
         device_mac_address=device_mac_address).first()
 
     if existing_device:
@@ -83,8 +83,7 @@ def ble_create_device(request):
             pairing_pass_key=pairing_pass_key,
             pairing_oob_key=pairing_oob_key,
             pairing_oobrn=pairing_oobrn,
-            endpoint_apps=endpoint_apps,
-            created_time=datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            endpoint_apps=endpoint_apps
         )
         session.add(entry)
 
@@ -97,11 +96,11 @@ def ble_update_device(request):
     """
     Update SCIM entry for BLE device.
     """
-    entry: BleDevice = BleDevice.query.get(entry_id)
+    entry: BleDevice = BleDevice.query.get(request.json["id"])
     # if ble is added, just add it.
     if not entry:
-        return create_ble_device(request)
-    
+        return ble_create_device(request)
+
     entry.version_support = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "versionSupport")

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -13,7 +13,7 @@ from models import EndpointApp, BleDevice
 from database import session
 from scim_error import blow_an_error
 
-def ble_create_device(request):
+def ble_create_device(request,core):
     """
     Process BLE SCIM creation request.  Returns SCIM object or error.
     """
@@ -87,7 +87,7 @@ def ble_create_device(request):
         session.add(entry)
 
         session.commit()
-        return entry.serialize()
+        return entry.serialize(core)
     except Exception as e:
         return blow_an_error(str(e),400)
 

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -91,14 +91,14 @@ def ble_create_device(request,core):
     except Exception as e:
         return blow_an_error(str(e),400)
 
-def ble_update_device(request):
+def ble_update_device(request,core):
     """
     Update SCIM entry for BLE device.
     """
     entry: BleDevice = BleDevice.query.get(request.json["id"])
     # if ble is added, just add it.
     if not entry:
-        return ble_create_device(request)
+        return ble_create_device(request,core)
 
     entry.version_support = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -98,7 +98,7 @@ def ble_create_device(request):
         session.add(entry)
 
         session.commit()
-        return make_response(jsonify(user.serialize()), 201)
+        return make_response(jsonify(entry.serialize()), 201)
     except Exception as e:
         return make_response(
             jsonify(

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -13,7 +13,7 @@ from database import session
 
 def ble_create_device(request,device_id):
     """
-    Process BLE SCIM creation request.  No return value.
+    Process BLE SCIM creation request.  Return a BleExtension()
     """
     ble_json = request.json.get("urn:ietf:params:scim:schemas:extension:ble:2.0:Device")
     device_mac_address = ble_json.get("deviceMacAddress")
@@ -69,9 +69,8 @@ def ble_update_device(request):
     entry: BleExtension = session.get(BleExtension,request.json["id"])
     # if ble is added in update, just add it.
     if not entry:
-        entry = ble_create_device(request,request.json["id"])
-        session.commit()
-        return
+        return ble_create_device(request,request.json["id"])
+
 
     ble_json=request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"]
     entry.version_support = ble_json.get("versionSupport")
@@ -89,5 +88,4 @@ def ble_update_device(request):
     entry.pairing_oobrn = ble_json.get(
         "urn:ietf:params:scim:schemas:extension:pairingOOB:2.0:Device").get("randNumber")
 
-    session.commit()
-    return
+    return entry

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -95,8 +95,8 @@ def ble_update_device(request,core):
     """
     Update SCIM entry for BLE device.
     """
-    entry: BleDevice = BleDevice.query.get(request.json["id"])
-    # if ble is added, just add it.
+    entry: BleDevice = session.get(BleDevice,request.json["id"])
+    # if ble is added in update, just add it.
     if not entry:
         return ble_create_device(request,core)
 

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -7,7 +7,6 @@
 This module implements BLE dispatch for SCIM.
 """
 
-import datetime
 from flask import jsonify, make_response
 from sqlalchemy import select
 from models import EndpointApp, BleDevice

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -8,9 +8,9 @@ This module implements BLE dispatch for SCIM.
 """
 
 from sqlalchemy import select
+from tiedie_exceptions import DeviceExists
 from models import EndpointApp, BleExtension
 from database import session
-from tiedie_exceptions import DeviceExists
 
 def ble_create_device(request):
     """

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -112,38 +112,38 @@ def ble_create_device(request):
             400,
         )
 
-def ble_update_device(request,user):
+def ble_update_device(request,entry):
     """
     Update SCIM entry for BLE device.
     """
 
-    user.id = request.json.get("id")
-    user.device_display_name = request.json.get("deviceDisplayName")
-    user.admin_state = request.json.get("adminState")
-    user.version_support = request.json[
+    entry.id = request.json.get("id")
+    entry.device_display_name = request.json.get("deviceDisplayName")
+    entry.admin_state = request.json.get("adminState")
+    entry.version_support = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "versionSupport")
-    user.device_mac_address = request.json[
+    entry.device_mac_address = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "deviceMacAddress")
-    user.is_random = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
+    entry.is_random = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "isRandom")
-    user.pairing_methods = request.json[
+    entry.pairing_methods = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "urn:ietf:params:scim:schemas:extension:pairingNull:2.0:Device")
-    user.pairing_null = request.json[
+    entry.pairing_null = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"].get(
         "urn:ietf:params:scim:schemas:extension:pairingNull:2.0:Device")
-    user.pairing_just_works_key = request.json[
+    entry.pairing_just_works_key = request.json[
         "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
         "urn:ietf:params:scim:schemas:extension:pairingJustWorks:2.0:Device"].get("key")
-    user.pairing_pass_key = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
+    entry.pairing_pass_key = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
         "urn:ietf:params:scim:schemas:extension:pairingPassKey:2.0:Device"].get("key")
-    user.pairing_oob_key = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
+    entry.pairing_oob_key = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
         "urn:ietf:params:scim:schemas:extension:pairingOOB:2.0:Device"].get("key")
-    user.pairing_oobrn = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
+    entry.pairing_oobrn = request.json["urn:ietf:params:scim:schemas:extension:ble:2.0:Device"][
         "urn:ietf:params:scim:schemas:extension:pairingOOB:2.0:Device"].get("randNumber")
-    user.modified_time = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    entry.modified_time = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     session.commit()
-    return make_response(jsonify(user.serialize()), 200)
+    return make_response(jsonify(entry.serialize()), 200)

--- a/gateway/scim_ble.py
+++ b/gateway/scim_ble.py
@@ -58,7 +58,7 @@ def ble_create_device(request,device_id):
         pairing_oob_key=pairing_oob_key,
         pairing_oobrn=pairing_oobrn,
     )
-    session.add(entry)
+    return entry
 
 
 
@@ -69,7 +69,7 @@ def ble_update_device(request):
     entry: BleExtension = session.get(BleExtension,request.json["id"])
     # if ble is added in update, just add it.
     if not entry:
-        ble_create_device(request,request.json["id"])
+        entry = ble_create_device(request,request.json["id"])
         session.commit()
         return
 

--- a/gateway/scim_error.py
+++ b/gateway/scim_error.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2023, Cisco Systems, Inc. and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+
+Simple error formating routine for scim.
+
+"""
+
+from flask import jsonify,make_response
+
+def blow_an_error(e,code):
+    """
+    Simple formating handling routine"
+    """
+    
+    return make_response(
+        jsonify(
+            {
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Error"],
+                "scimType": "invalidSyntax",
+                "detail": e,
+                "status": code,
+                }
+        ),
+        code,
+    )

--- a/gateway/scim_error.py
+++ b/gateway/scim_error.py
@@ -11,7 +11,7 @@ Simple error formating routine for scim.
 
 from flask import jsonify,make_response
 
-def blow_an_error(e,code):
+def blow_an_error(e,code,scim_code = "invalidSyntax"):
     """
     Simple formating handling routine"
     """
@@ -20,7 +20,7 @@ def blow_an_error(e,code):
         jsonify(
             {
                 "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Error"],
-                "scimType": "invalidSyntax",
+                "scimType": scim_code,
                 "detail": e,
                 "status": code,
                 }

--- a/gateway/scim_error.py
+++ b/gateway/scim_error.py
@@ -15,7 +15,7 @@ def blow_an_error(e,code):
     """
     Simple formating handling routine"
     """
-    
+
     return make_response(
         jsonify(
             {

--- a/gateway/tests/test_scim.py
+++ b/gateway/tests/test_scim.py
@@ -121,6 +121,7 @@ def test_get_device(client: FlaskClient, api_key):
         }
     )
 
+    print(response.json)
     device_id = response.json["id"]
 
     response = client.get(f"/scim/v2/Devices/{device_id}", headers={

--- a/gateway/tests/test_scim.py
+++ b/gateway/tests/test_scim.py
@@ -79,7 +79,6 @@ def test_create_device(client: FlaskClient, api_key: str):
     assert response.json["schemas"] == [
         'urn:ietf:params:scim:schemas:core:2.0:Device',
         'urn:ietf:params:scim:schemas:extension:ble:2.0:Device',
-        'urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device'
     ]
 
 

--- a/gateway/tests/test_scim.py
+++ b/gateway/tests/test_scim.py
@@ -143,6 +143,18 @@ def test_get_device(client: FlaskClient, api_key):
     assert len(response.json["Resources"]) == 1
     assert response.json["Resources"][0]["id"] == device_id
 
+    # Test filter
+    response = client.get(
+        "/scim/v2/Devices?filter=deviceMacAddress eq \"AA:BB:CC:11:22:33\"",
+        headers={
+            "x-api-key": api_key
+        })
+
+    print(response.json)
+    assert response.status_code == 200
+    assert response.json["totalResults"] == 1
+    assert response.json["Resources"][0]["id"] == device_id
+
 
 def test_delete_device(client: FlaskClient, api_key):
     """ Test DELETE device """

--- a/gateway/tests/test_scim.py
+++ b/gateway/tests/test_scim.py
@@ -121,7 +121,6 @@ def test_get_device(client: FlaskClient, api_key):
         }
     )
 
-    print(response.json)
     device_id = response.json["id"]
 
     response = client.get(f"/scim/v2/Devices/{device_id}", headers={

--- a/gateway/tiedie_exceptions.py
+++ b/gateway/tiedie_exceptions.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023, Cisco Systems, Inc. and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Exceptions that might be raised in the gateway
+"""
+
+class DeviceExists(Exception):
+    """
+    This is raised when trying to create a device that already exists.
+    """

--- a/python-sdk/sample-python-app/src/app.py
+++ b/python-sdk/sample-python-app/src/app.py
@@ -234,7 +234,7 @@ def add_device():
 
     control_client.register_topic(
         topic,
-        device,
+        response.body,
         ConnectionRegistrationOptions(
             data_format=DataFormat.DEFAULT,
             data_apps=[app.config['DATA_APP_ID']]

--- a/python-sdk/tiedie/api/data_receiver_client.py
+++ b/python-sdk/tiedie/api/data_receiver_client.py
@@ -29,7 +29,7 @@ class DataReceiverClient:
         self.host = host
         self.port = port
         self.authenticator = authenticator
-        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2,
+        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1,
             client_id=authenticator.get_client_id(), clean_session=True)
         self.authenticator.set_auth_options_mqtt(self.mqtt_client, disable_tls, insecure_tls)
         self.mqtt_client.on_connect = self.__on_connect

--- a/python-sdk/tiedie/api/data_receiver_client.py
+++ b/python-sdk/tiedie/api/data_receiver_client.py
@@ -29,7 +29,7 @@ class DataReceiverClient:
         self.host = host
         self.port = port
         self.authenticator = authenticator
-        self.mqtt_client = mqtt.Client(
+        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2,
             client_id=authenticator.get_client_id(), clean_session=True)
         self.authenticator.set_auth_options_mqtt(self.mqtt_client, disable_tls, insecure_tls)
         self.mqtt_client.on_connect = self.__on_connect


### PR DESCRIPTION
This PR is the first round of normalization for other technologies.  More work will be needed, but the databases are separated, and BLE is somewhat more walled off than it was.

Also changed: 

* Error handling is not consolidated.
* MQTT client pylint was failing due to lack of versioning information in the constructor
* Get rid of deprecated Query.get call from sqlalchemy