### PR TITLE
Move to paho.mqtt.VERSION2

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -48,7 +48,7 @@ def onboarding_apiauth(name):
 
 def mqtt_connect() -> mqtt.Client:
     """ Function MQTT connect """
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     client.tls_set(ca_certs="ca_certificates/ca.pem")
     client.tls_insecure_set(True)
     client.username_pw_set("admin", "admin")

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -56,7 +56,7 @@ def authenticate_user(func):
 
     @wraps(func)
     def check_apikey(*args, **kwargs):
-        client_cert = request.environ['peercert']
+        client_cert = request.environ.get('peercert')
         if client_cert:
             if session.scalar(
                 select(EndpointApp)

--- a/gateway/tests/mosquitto.conf
+++ b/gateway/tests/mosquitto.conf
@@ -1,0 +1,4 @@
+persistence false
+allow_anonymous true
+log_type all
+listener 1883

--- a/gateway/tests/mosquitto_container.py
+++ b/gateway/tests/mosquitto_container.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023, Cisco Systems, Inc. and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
+""" MosquittoContainer class. """
+
+from typing import List, Optional
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
+import paho.mqtt.client as mqtt
+
+
+class MosquittoContainer(DockerContainer):
+    """ Test container for Mosquitto. """
+
+    def __init__(
+            self,
+            image: str = "eclipse-mosquitto:latest",
+            port: Optional[int] = 1883,
+            volume_mappings: List[tuple[str, str]] = None
+    ):
+        super().__init__(image)
+        self.port = port
+        self.with_exposed_ports(self.port)
+        if volume_mappings is None:
+            volume_mappings = []
+        for host, container in volume_mappings:
+            self.with_volume_mapping(host, container)
+
+    @wait_container_is_ready()
+    def readiness_probe(self) -> bool:
+        """ Check if the container is ready. """
+        wait_for_logs(self, "mosquitto version .* running")
+
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+        client.username_pw_set("test", "test")
+        client.connect(self.get_container_host_ip(), int(self.get_exposed_port(self.port)), 60)
+        client.loop(timeout=1.0)
+
+        if client.is_connected():
+            client.disconnect()
+            client.loop_stop()
+            return self
+
+        raise RuntimeError("Failed to connect to Mosquitto")
+
+    def start(self) -> "MosquittoContainer":
+        """ Start the test container. """
+        super().start()
+        self.readiness_probe()
+        return self

--- a/gateway/tests/test_data_producer.py
+++ b/gateway/tests/test_data_producer.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2023, Cisco Systems, Inc. and/or its affiliates.
+# All rights reserved.
+# See LICENSE file in this distribution.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test gateway data producer.
+"""
+
+import os
+import time
+import uuid
+
+import paho.mqtt.client as mqtt
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from testcontainers.postgres import PostgresContainer
+
+from app_factory import create_app
+from data_producer import DataProducer
+from database import db
+from models import OnboardingAppKey
+from proto import data_app_pb2
+from tests.mosquitto_container import MosquittoContainer
+
+
+@pytest.fixture(name="postgres")
+def fixture_postgres():
+    """ Postgres container """
+    with PostgresContainer("postgres:13.1") as p:
+        yield p
+
+
+@pytest.fixture(name="mosquitto")
+def fixture_mosquitto():
+    """ Mosquitto container """
+    path = os.path.abspath(os.path.dirname(__file__))
+    with MosquittoContainer(volume_mappings=[
+        (path + "/mosquitto.conf", "/mosquitto/config/mosquitto.conf"),
+    ]) as m:
+        yield m
+
+
+@pytest.fixture(name="mqtt_client")
+def fixture_mqtt_client(mosquitto: MosquittoContainer):
+    """ MQTT client """
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.connect(mosquitto.get_container_host_ip(),
+                   int(mosquitto.get_exposed_port(1883)), 60)
+    client.loop_start()
+    yield client
+    client.disconnect()
+    client.loop_stop()
+
+
+@pytest.fixture(name="mqtt_client2")
+def fixture_mqtt_client2(mosquitto: MosquittoContainer):
+    """ MQTT client """
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.username_pw_set("control-app", "test")
+    client.connect(mosquitto.get_container_host_ip(),
+                   int(mosquitto.get_exposed_port(1883)), 60)
+    client.loop_start()
+    yield client
+    client.disconnect()
+    client.loop_stop()
+
+
+@pytest.fixture(name="app")
+def fixture_app(postgres: PostgresContainer):
+    """ Flask application """
+    app = create_app(postgres.get_connection_url())
+
+    with app.app_context():
+        db.create_all()
+
+    yield app
+
+
+@pytest.fixture(name="client")
+def fixture_client(app: Flask) -> FlaskClient:
+    """ Flask client """
+    return app.test_client()
+
+
+@pytest.fixture(name="api_key")
+def fixture_api_key(app):
+    """ Create onboarding API key for testing """
+    with app.app_context():
+        key = uuid.uuid4()
+        authkey = OnboardingAppKey("onboarding-app", str(key))
+        db.session.add(authkey)
+        db.session.commit()
+        yield key
+
+
+@pytest.fixture(name="data_producer")
+def fixture_data_producer(mqtt_client: mqtt.Client, app: Flask):
+    """ Data producer """
+    yield DataProducer(mqtt_client, app)
+
+
+def test_publish_notification(mqtt_client2: mqtt.Client,
+                              data_producer: DataProducer,
+                              client: FlaskClient,
+                              api_key: str):
+    """ Test publish notification """
+
+    response = client.post(
+        "/scim/v2/EndpointApps",
+        json={
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:EndpointApp"],
+            "applicationType": "deviceControl",
+            "applicationName": "control-app",
+        },
+        headers={
+            "x-api-key": api_key
+        }
+    )
+
+    assert response.status_code == 201
+
+    control_app_id = response.json["id"]
+    control_api_key = response.json["clientToken"]
+
+    response = client.post(
+        "/scim/v2/Devices",
+        json={
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Device",
+                        "urn:ietf:params:scim:schemas:extension:ble:2.0:Device"],
+            "deviceDisplayName": "BLE Heart Monitor",
+            "adminState": True,
+            "urn:ietf:params:scim:schemas:extension:ble:2.0:Device": {
+                "versionSupport": ["5.3"],
+                "deviceMacAddress": "AA:BB:CC:11:22:33",
+                "isRandom": False,
+                "mobility": True
+            },
+            "urn:ietf:params:scim:schemas:extension:endpointAppExt:2.0:Device": {
+                "applications": [
+                    {
+                        "value": control_app_id
+                    }
+                ]
+            }
+        }, headers={
+            "x-api-key": api_key
+        }
+    )
+
+    assert response.status_code == 201
+    device_id = response.json["id"]
+
+    response = client.post(
+        "/nipc/registration/topic",
+        json={
+            "id": device_id,
+            "topic": "ble/notifications",
+            "dataFormat": "default",
+            "ble": {
+                "type": "gatt",
+                "serviceID": "180d",
+                "characteristicID": "2a37"
+            }
+        }, headers={
+            "x-api-key": control_api_key
+        }
+    )
+
+    assert response.status_code == 200
+
+    def on_message(_client, _userdata, message: mqtt.MQTTMessage):
+        print(
+            f"Received message '{message.payload}' on topic '{message.topic}'")
+        data_subscription = data_app_pb2.DataSubscription()  # pylint: disable=no-member
+        data_subscription.ParseFromString(message.payload)
+        assert data_subscription.device_id == device_id
+        assert data_subscription.ble_subscription.service_uuid == "180d"
+        assert data_subscription.ble_subscription.characteristic_uuid == "2a37"
+        assert data_subscription.data == b"\x00\x00"
+
+    mqtt_client2.on_message = on_message
+    mqtt_client2.subscribe("ble/notifications")
+
+    data_producer.publish_notification("AA:BB:CC:11:22:33",
+                                       "180d",
+                                       "2a37",
+                                       b"\x00\x00")
+
+    # wait for on_message callback to be fired
+    time.sleep(1)

--- a/python-sdk/sample-python-app/src/app.py
+++ b/python-sdk/sample-python-app/src/app.py
@@ -24,7 +24,7 @@ from tiedie.models import (Device, DataFormat, BleDataParameter,
                            DataRegistrationOptions, BleExtension,
                            EndpointAppsExtension)
 from tiedie.models.ble import BleConnectRequest, BleService
-from tiedie.models.scim import Application
+from tiedie.models.scim import Application, PairingPassKey
 import configuration
 
 
@@ -149,7 +149,8 @@ class ConnectionStatusHandler(Namespace):
                 print(e)
 
         print("message: ", message)
-        data_receiver_client.subscribe(message, callback)
+        if len(message) != 0:
+            data_receiver_client.subscribe(message, callback)
 
 
 socketio.on_namespace(ConnectionStatusHandler('/connectionstatus'))
@@ -216,7 +217,7 @@ def add_device():
             device_mac_address=content['deviceMacAddress'],
             version_support=version_support,
             is_random=is_random,
-            pass_key=int(content['passKey'])
+            pairing_pass_key=PairingPassKey(key=int(content['passKey']))
         ),
         endpoint_apps_extension=EndpointAppsExtension(applications=[
             Application(value=endpoint_app.application_id) for endpoint_app in endpoint_apps

--- a/python-sdk/tiedie/api/data_receiver_client.py
+++ b/python-sdk/tiedie/api/data_receiver_client.py
@@ -29,7 +29,7 @@ class DataReceiverClient:
         self.host = host
         self.port = port
         self.authenticator = authenticator
-        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1,
+        self.mqtt_client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2,
             client_id=authenticator.get_client_id(), clean_session=True)
         self.authenticator.set_auth_options_mqtt(self.mqtt_client, disable_tls, insecure_tls)
         self.mqtt_client.on_connect = self.__on_connect
@@ -74,16 +74,16 @@ class DataReceiverClient:
         """
         self.mqtt_client.unsubscribe(topic)
 
-    def __on_message(self, message):
+    def __on_message(self, _userdata, message):
         print("Received message: " + str(message.payload))
 
-    def __on_connect(self, _client, _userdata, _flags, rc):
-        if rc == 0:
+    def __on_connect(self, _client, _userdata, _connect_flags, reason_code, _properties):
+        if reason_code == 0:
             print("Connected to broker")
             self.connected = True
         else:
-            print("Connection failed with error code " + str(rc))
+            print("Connection failed with error code " + str(reason_code))
 
-    def __on_disconnect(self, _client, _userdata, _rc):
+    def __on_disconnect(self, _client, _userdata, _flags, _reason_code, _properties):
         print("Disconnected from broker")
         self.connected = False

--- a/python-sdk/tiedie/api/data_receiver_client.py
+++ b/python-sdk/tiedie/api/data_receiver_client.py
@@ -64,7 +64,7 @@ class DataReceiverClient:
             callback(data_subscription)
 
         self.mqtt_client.subscribe(topic, qos=0)
-        self.mqtt_client.on_message = on_message
+        self.mqtt_client.message_callback_add(topic, on_message)
 
     def unsubscribe(self, topic: str):
         """ Unsubscribe from a topic.

--- a/python-sdk/tiedie/models/scim.py
+++ b/python-sdk/tiedie/models/scim.py
@@ -189,5 +189,5 @@ class Device(BaseModel):
                 "urn:ietf:params:scim:schemas:extension:zigbee:2.0:Device")
         if self.endpoint_apps_extension is not None:
             _schemas.append(
-                "urn:ietf:params:scim:schemas:extension:endpointApps:2.0:Device")
+                "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device")
         return _schemas

--- a/python-sdk/tiedie/tests/test_scim.py
+++ b/python-sdk/tiedie/tests/test_scim.py
@@ -234,7 +234,7 @@ def test_endpoint_extension():
         "schemas": [
             "urn:ietf:params:scim:schemas:core:2.0:Device",
             "urn:ietf:params:scim:schemas:extension:ble:2.0:Device",
-            "urn:ietf:params:scim:schemas:extension:endpointApps:2.0:Device"
+            "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device"
         ]
     }, separators=(',', ':'))
 


### PR DESCRIPTION
Updated the callbacks to use VERSION2. Fixes #60. 

Also added a test to verify the MQTT publishing from the gateway. 

The PR also has minor fixes in the SDK to: 
1. send the correct endpointAppsExt schema name
2. Updated MQTT callbacks
3. Send pass key correctly from the sample app